### PR TITLE
Add endpoint to fetch queue length for course.

### DIFF
--- a/broadway/api/handlers/client.py
+++ b/broadway/api/handlers/client.py
@@ -270,3 +270,27 @@ class CourseWorkerNodeHandler(ClientAPIHandler):
                 {"message": "scope {} has not been implemented yet".format(scope)}, 404
             )
             return
+
+
+class CourseQueueLengthHandler(ClientAPIHandler):
+    @authenticate_course
+    @schema.validate(
+        output_schema={
+            "type": "object",
+            "properties": {"length": {"type": "number"}},
+            "required": ["length"],
+            "additionalProperties": False,
+        },
+        on_empty_404=True,
+    )
+    def get(self, *args, **kwargs):
+        course_id = kwargs["course_id"]
+        queue = self.settings["QUEUE"]
+
+        if queue.contains_key(course_id):
+            return {"length": queue.get_queue_length_by_key(course_id)}
+        else:
+            self.abort(
+                {"message": f"{course_id} does not exist as a course in the queue"}
+            )
+            return

--- a/broadway/api/handlers/client.py
+++ b/broadway/api/handlers/client.py
@@ -287,10 +287,8 @@ class CourseQueueLengthHandler(ClientAPIHandler):
         course_id = kwargs["course_id"]
         queue = self.settings["QUEUE"]
 
+        length = 0
         if queue.contains_key(course_id):
-            return {"length": queue.get_queue_length_by_key(course_id)}
-        else:
-            self.abort(
-                {"message": f"{course_id} does not exist as a course in the queue"}
-            )
-            return
+            length = queue.get_queue_length_by_key(course_id)
+
+        return {"length": length}

--- a/broadway/api/utils/bootstrap.py
+++ b/broadway/api/utils/bootstrap.py
@@ -168,6 +168,10 @@ def initialize_app(
                 ),
                 client_handlers.CourseWorkerNodeHandler,
             ),
+            (
+                r"/api/v1/queue_length/{}".format(id_regex.format("course_id")),
+                client_handlers.CourseQueueLengthHandler,
+            ),
             # ----------------------------------
             # ------- Worker Endpoints ---------
             (

--- a/broadway/api/utils/bootstrap.py
+++ b/broadway/api/utils/bootstrap.py
@@ -169,7 +169,7 @@ def initialize_app(
                 client_handlers.CourseWorkerNodeHandler,
             ),
             (
-                r"/api/v1/queue_length/{}".format(id_regex.format("course_id")),
+                r"/api/v1/queue/{}/length".format(id_regex.format("course_id")),
                 client_handlers.CourseQueueLengthHandler,
             ),
             # ----------------------------------

--- a/broadway/api/utils/multiqueue.py
+++ b/broadway/api/utils/multiqueue.py
@@ -43,3 +43,11 @@ class MultiQueue:
                 pass
 
         raise Empty("All the queues in the MultiQueue are empty.")
+
+    def get_queue_length_by_key(self, key):
+        if not self.contains_key(key):
+            raise Exception(f"{key} does not exist in the MultiQueue.")
+        return self.queues[key].qsize()
+
+    def contains_key(self, key):
+        return key in self.queues

--- a/tests/api/_fixtures/grading_runs.py
+++ b/tests/api/_fixtures/grading_runs.py
@@ -12,3 +12,7 @@ one_student_and_both = {
     "students_env": [{"netid": "test net id"}],
     "post_processing_env": {"type": "post"},
 }
+
+
+def generate_n_student_jobs(n):
+    return {"students_env": [{"netid": "test net id"}] * n}

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -181,7 +181,7 @@ class ClientMixin(AsyncHTTPMixin):
 
     def get_course_queue_length(self, course_id, header, expected_code):
         response = self.fetch(
-            self.get_url("/api/v1/queue_length/{}".format(course_id)),
+            self.get_url("/api/v1/queue/{}/length".format(course_id)),
             method="GET",
             headers=header,
         )

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -179,6 +179,18 @@ class ClientMixin(AsyncHTTPMixin):
             response_body = json.loads(response.body.decode("utf-8"))
             return response_body["data"]
 
+    def get_course_queue_length(self, course_id, header, expected_code):
+        response = self.fetch(
+            self.get_url("/api/v1/queue_length/{}".format(course_id)),
+            method="GET",
+            headers=header,
+        )
+        self.assertEqual(response.code, expected_code)
+
+        if response.code == 200:
+            response_body = json.loads(response.body.decode("utf-8"))
+            return response_body["data"]
+
 
 class GraderMixin(AsyncHTTPMixin):
     def register_worker(

--- a/tests/api/integration/test_client.py
+++ b/tests/api/integration/test_client.py
@@ -403,5 +403,5 @@ class CourseQueueLengthEndpointTest(BaseTest):
 
         # No jobs should have been pushed to the queue yet,
         # since we didn't start any grading runs.
-        self.get_course_queue_length(self.course1, self.client_header1, 400)
-        self.get_course_queue_length(self.course1, self.client_header1, 400)
+        self.assertLengthEquals(self.course1, self.client_header1, 0)
+        self.assertLengthEquals(self.course2, self.client_header2, 0)

--- a/tests/api/unit/test_utils.py
+++ b/tests/api/unit/test_utils.py
@@ -62,6 +62,15 @@ class TestMultiQueue(BaseTest):
         self.multiqueue.push("cs241", 241)
         self.multiqueue.push("cs241", 295 - 41)
 
+        self.assertTrue(self.multiqueue.contains_key("cs225"))
+        self.assertTrue(self.multiqueue.contains_key("cs233"))
+        self.assertTrue(self.multiqueue.contains_key("cs241"))
+        self.assertFalse(self.multiqueue.contains_key("ece411"))
+
+        self.assertEqual(2, self.multiqueue.get_queue_length_by_key("cs225"))
+        self.assertEqual(1, self.multiqueue.get_queue_length_by_key("cs233"))
+        self.assertEqual(2, self.multiqueue.get_queue_length_by_key("cs241"))
+
         self.assertEqual(3, len(self.multiqueue.queues))
         self.assertEqual(2, self.multiqueue.queues["cs225"].qsize())
         self.assertEqual(1, self.multiqueue.queues["cs233"].qsize())


### PR DESCRIPTION
This diff adds an endpoint for clients to fetch how long the queue is for a given course. This way, on-demand can now use this endpoint to show students an estimate of how many jobs are currently queued before they click grade.

I've also added some tests for this (and ran the linting/test commands in the travis.yml).

Related issue: https://github.com/illinois-cs241/broadway-on-demand/issues/80