### PR TITLE
Update BW Grader Dockerfile

### DIFF
--- a/ops/grader.Dockerfile
+++ b/ops/grader.Dockerfile
@@ -1,6 +1,7 @@
-ARG INSTALL_PATH=/opt/broadway
-
 FROM python:3.6.9-alpine
+
+ARG INSTALL_PATH=/opt/broadway
+RUN mkdir -p ${INSTALL_PATH}
 
 ADD requirements.txt ${INSTALL_PATH}
 
@@ -11,5 +12,6 @@ ADD broadway ${INSTALL_PATH}/broadway
 
 ENV PYTHONPATH "${PYTHONPATH}:${INSTALL_PATH}"
 
+WORKDIR /srv/cs241/broadway-grader
 ENTRYPOINT ["python", "-m", "broadway.grader"]
 CMD []


### PR DESCRIPTION
Few changes:
- Move the `ARG` for `INSTALL_PATH` from before the `FROM`  to after. Previously, broadway was being installed in `/` rather than `/opt/broadway` as the Dockerfile intended to. This is what the current BW graders look like:
    ```
    ericsz2@fa20-cs241-grd-13:~$ sudo docker exec -it 6925e00437c0 /bin/sh
    / # ls
    bin               home              mnt               root              sys
    broadway          lib               opt               run               tmp
    dev               log               proc              sbin              usr
    etc               media             requirements.txt  srv               var
    ```

    "An ARG declared before a FROM is outside of a build stage, so it can’t be used in any instruction after a FROM." from https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact. 

- Set the `WORKDIR` to `/srv/cs241/broadway-grader`. This way, we can add `-v /srv/cs241/broadway-grader:/srv/cs241/broadway-grader` as an argument when starting the container which will properly clean up the `tmp********` directories in the grader machines.

I've tested these changes on grader 13 a while back. I built a local image using the updated Dockerfile and spun up a BW grader using that, then scheduled a run on grader 13, then verified that the `tmp********` directory that was created for the grading pipeline was also cleaned up properly.