### PR TITLE
Add grading job queue position endpoint

### DIFF
--- a/broadway/api/handlers/client.py
+++ b/broadway/api/handlers/client.py
@@ -192,6 +192,36 @@ class GradingRunStatusHandler(ClientAPIHandler):
         }
 
 
+class GradingRunQueuePosition(ClientAPIHandler):
+    @authenticate_course
+    @schema.validate(
+        output_schema={
+            "type": "object",
+            "properties": {"position": {"type": "number"}},
+            "required": ["position"],
+            "additionalProperties": False,
+        },
+        on_empty_404=True,
+    )
+    def get(self, *args, **kwargs):
+        course_id = kwargs["course_id"]
+        grading_run_id = kwargs.get("run_id")
+        queue = self.settings["QUEUE"]
+
+        if not queue.contains_key(course_id):
+            self.abort(
+                {"message": f"{course_id} does not exist as a course in the queue"}
+            )
+            return
+
+        queue_position = queue.get_position_in_queue(course_id, grading_run_id)
+        if queue_position == -1:
+            self.abort(
+                {"message": f"{grading_run_id} was not found in the queue"}
+            )
+
+        return {"position", queue_position}
+
 class GradingJobLogHandler(ClientAPIHandler):
     @authenticate_course
     @schema.validate(

--- a/broadway/api/handlers/client.py
+++ b/broadway/api/handlers/client.py
@@ -270,3 +270,27 @@ class CourseWorkerNodeHandler(ClientAPIHandler):
                 {"message": "scope {} has not been implemented yet".format(scope)}, 404
             )
             return
+
+
+class CourseQueueLengthHandler(ClientAPIHandler):
+    @authenticate_course
+    @schema.validate(
+        output_schema={
+            "type": "object",
+            "properties": {"length": {"type": "number"}},
+            "required": ["length"],
+            "additionalProperties": False,
+        },
+        on_empty_404=True,
+    )
+    def get(self, *args, **kwargs):
+        course_id = kwargs["course_id"]
+        queue = self.settings["QUEUE"]
+
+        if queue.contains_key(course_id):
+            return {"length": queue.get_queue_length_by_key(course_id)}
+        else:
+            self.abort(
+                {"message": f"{course_id} does not exist as a course in the queue"}
+            )
+            return

--- a/broadway/api/handlers/client.py
+++ b/broadway/api/handlers/client.py
@@ -192,36 +192,6 @@ class GradingRunStatusHandler(ClientAPIHandler):
         }
 
 
-class GradingRunQueuePosition(ClientAPIHandler):
-    @authenticate_course
-    @schema.validate(
-        output_schema={
-            "type": "object",
-            "properties": {"position": {"type": "number"}},
-            "required": ["position"],
-            "additionalProperties": False,
-        },
-        on_empty_404=True,
-    )
-    def get(self, *args, **kwargs):
-        course_id = kwargs["course_id"]
-        grading_run_id = kwargs.get("run_id")
-        queue = self.settings["QUEUE"]
-
-        if not queue.contains_key(course_id):
-            self.abort(
-                {"message": f"{course_id} does not exist as a course in the queue"}
-            )
-            return
-
-        queue_position = queue.get_position_in_queue(course_id, grading_run_id)
-        if queue_position == -1:
-            self.abort(
-                {"message": f"{grading_run_id} was not found in the queue"}
-            )
-
-        return {"position", queue_position}
-
 class GradingJobLogHandler(ClientAPIHandler):
     @authenticate_course
     @schema.validate(
@@ -324,3 +294,34 @@ class CourseQueueLengthHandler(ClientAPIHandler):
                 {"message": f"{course_id} does not exist as a course in the queue"}
             )
             return
+
+
+class GradingRunQueuePosition(ClientAPIHandler):
+    @authenticate_course
+    @schema.validate(
+        output_schema={
+            "type": "object",
+            "properties": {"position": {"type": "number"}},
+            "required": ["position"],
+            "additionalProperties": False,
+        },
+        on_empty_404=True,
+    )
+    def get(self, *args, **kwargs):
+        course_id = kwargs["course_id"]
+        grading_run_id = kwargs.get("run_id")
+        queue = self.settings["QUEUE"]
+
+        if not queue.contains_key(course_id):
+            self.abort(
+                {"message": f"{course_id} does not exist as a course in the queue"}
+            )
+            return
+
+        queue_position = queue.get_position_in_queue(course_id, grading_run_id)
+        if queue_position == -1:
+            self.abort(
+                {"message": f"{grading_run_id} was not found in the queue"}
+            )
+
+        return {"position", queue_position}

--- a/broadway/api/handlers/client.py
+++ b/broadway/api/handlers/client.py
@@ -296,7 +296,7 @@ class CourseQueueLengthHandler(ClientAPIHandler):
             return
 
 
-class GradingRunQueuePosition(ClientAPIHandler):
+class GradingRunQueuePositionHandler(ClientAPIHandler):
     @authenticate_course
     @schema.validate(
         output_schema={

--- a/broadway/api/handlers/client.py
+++ b/broadway/api/handlers/client.py
@@ -320,8 +320,6 @@ class GradingRunQueuePositionHandler(ClientAPIHandler):
 
         queue_position = queue.get_position_in_queue(course_id, grading_run_id)
         if queue_position == -1:
-            self.abort(
-                {"message": f"{grading_run_id} was not found in the queue"}
-            )
+            self.abort({"message": f"{grading_run_id} was not found in the queue"})
 
         return {"position", queue_position}

--- a/broadway/api/handlers/client.py
+++ b/broadway/api/handlers/client.py
@@ -288,7 +288,7 @@ class CourseQueueLengthHandler(ClientAPIHandler):
         queue = self.settings["QUEUE"]
 
         if queue.contains_key(course_id):
-            return {"length": queue.get_queue_length_by_key(course_id)}
+            return {"length": queue.get_queue_length(course_id)}
         else:
             self.abort(
                 {"message": f"{course_id} does not exist as a course in the queue"}

--- a/broadway/api/utils/bootstrap.py
+++ b/broadway/api/utils/bootstrap.py
@@ -168,6 +168,10 @@ def initialize_app(
                 ),
                 client_handlers.CourseWorkerNodeHandler,
             ),
+            (
+                r"/api/v1/queue/{}/length".format(id_regex.format("course_id")),
+                client_handlers.CourseQueueLengthHandler,
+            ),
             # ----------------------------------
             # ------- Worker Endpoints ---------
             (

--- a/broadway/api/utils/bootstrap.py
+++ b/broadway/api/utils/bootstrap.py
@@ -172,6 +172,12 @@ def initialize_app(
                 r"/api/v1/queue/{}/length".format(id_regex.format("course_id")),
                 client_handlers.CourseQueueLengthHandler,
             ),
+            (
+                r"/api/v1/queue/{}/{}/position".format(
+                    id_regex.format("course_id"), id_regex.format("run_id")
+                ),
+                client_handlers.GradingRunQueuePosition,
+            ),
             # ----------------------------------
             # ------- Worker Endpoints ---------
             (

--- a/broadway/api/utils/bootstrap.py
+++ b/broadway/api/utils/bootstrap.py
@@ -176,7 +176,7 @@ def initialize_app(
                 r"/api/v1/queue/{}/{}/position".format(
                     id_regex.format("course_id"), id_regex.format("run_id")
                 ),
-                client_handlers.GradingRunQueuePosition,
+                client_handlers.GradingRunQueuePositionHandler,
             ),
             # ----------------------------------
             # ------- Worker Endpoints ---------

--- a/broadway/api/utils/multiqueue.py
+++ b/broadway/api/utils/multiqueue.py
@@ -19,6 +19,10 @@ class MultiQueue:
         self.queues[queue_id] = Queue()
         self.keys.append(queue_id)
 
+    def _ensure_queue_exists(self, queue_id):
+        if queue_id not in self.queues:
+            raise Exception(f"{queue_id} does not exist in the MultiQueue.")
+
     def push(self, queue_id, elem):
         if queue_id not in self.queues:
             self._add_queue(queue_id)
@@ -44,10 +48,16 @@ class MultiQueue:
 
         raise Empty("All the queues in the MultiQueue are empty.")
 
-    def get_queue_length_by_key(self, key):
-        if not self.contains_key(key):
-            raise Exception(f"{key} does not exist in the MultiQueue.")
-        return self.queues[key].qsize()
-
     def contains_key(self, key):
         return key in self.queues
+
+    def get_queue_length(self, queue_id):
+        self._ensure_queue_exists(queue_id)
+        return self.queues[queue_id].qsize()
+
+    def get_position_in_queue(self, queue_id, key):
+        self._ensure_queue_exists(queue_id)
+        try:
+            return self.queues[queue_id].queue.index(key)
+        except ValueError:
+            return -1

--- a/broadway/api/utils/multiqueue.py
+++ b/broadway/api/utils/multiqueue.py
@@ -43,3 +43,11 @@ class MultiQueue:
                 pass
 
         raise Empty("All the queues in the MultiQueue are empty.")
+
+    def get_queue_length_by_key(self, key):
+        if not self.contains_key(key):
+            raise Exception(f"{key} does not exist in the MultiQueue.")
+        return self.queues[key].qsize()
+
+    def contains_key(self, key):
+        return key in self.queues

--- a/tests/api/_fixtures/grading_runs.py
+++ b/tests/api/_fixtures/grading_runs.py
@@ -12,3 +12,7 @@ one_student_and_both = {
     "students_env": [{"netid": "test net id"}],
     "post_processing_env": {"type": "post"},
 }
+
+
+def generate_n_student_jobs(n):
+    return {"students_env": [{"netid": "test net id"}] * n}

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -191,6 +191,21 @@ class ClientMixin(AsyncHTTPMixin):
             response_body = json.loads(response.body.decode("utf-8"))
             return response_body["data"]
 
+    def get_grading_run_queue_position(
+        self, course_id, grading_run_id, header, expected_code
+    ):
+        response = self.fetch(
+            self.get_url(
+                "/api/v1/queue/{}/{}/position".format(course_id, grading_run_id)
+            ),
+            method="GET",
+            headers=header,
+        )
+        self.assertEqual(response.code, expected_code)
+
+        if response.code == 200:
+            response_body = json.loads(response.body.decode("utf-8"))
+            return response_body["data"]
 
 class GraderMixin(AsyncHTTPMixin):
     def register_worker(

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -207,6 +207,7 @@ class ClientMixin(AsyncHTTPMixin):
             response_body = json.loads(response.body.decode("utf-8"))
             return response_body["data"]
 
+
 class GraderMixin(AsyncHTTPMixin):
     def register_worker(
         self, header, expected_code=200, worker_id=None, hostname="mock_hostname"

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -179,6 +179,18 @@ class ClientMixin(AsyncHTTPMixin):
             response_body = json.loads(response.body.decode("utf-8"))
             return response_body["data"]
 
+    def get_course_queue_length(self, course_id, header, expected_code):
+        response = self.fetch(
+            self.get_url("/api/v1/queue/{}/length".format(course_id)),
+            method="GET",
+            headers=header,
+        )
+        self.assertEqual(response.code, expected_code)
+
+        if response.code == 200:
+            response_body = json.loads(response.body.decode("utf-8"))
+            return response_body["data"]
+
 
 class GraderMixin(AsyncHTTPMixin):
     def register_worker(

--- a/tests/api/integration/test_client.py
+++ b/tests/api/integration/test_client.py
@@ -405,3 +405,13 @@ class CourseQueueLengthEndpointTest(BaseTest):
         # since we didn't start any grading runs.
         self.get_course_queue_length(self.course1, self.client_header1, 400)
         self.get_course_queue_length(self.course1, self.client_header1, 400)
+
+
+class GradingRunQueuePositionEndpointTest(BaseTest):
+    def assert_position_equals(self, course_id, grading_run_id, header, expected_pos):
+        pos = self.get_grading_run_queue_position(
+            course_id, grading_run_id, header, 200
+        )["length"]
+        self.assertEqual(expected_pos, pos)
+
+    # TODO: Add tests

--- a/tests/api/unit/test_utils.py
+++ b/tests/api/unit/test_utils.py
@@ -62,6 +62,15 @@ class TestMultiQueue(BaseTest):
         self.multiqueue.push("cs241", 241)
         self.multiqueue.push("cs241", 295 - 41)
 
+        self.assertTrue(self.multiqueue.contains_key("cs225"))
+        self.assertTrue(self.multiqueue.contains_key("cs233"))
+        self.assertTrue(self.multiqueue.contains_key("cs241"))
+        self.assertFalse(self.multiqueue.contains_key("ece411"))
+
+        self.assertEqual(2, self.multiqueue.get_queue_length_by_key("cs225"))
+        self.assertEqual(1, self.multiqueue.get_queue_length_by_key("cs233"))
+        self.assertEqual(2, self.multiqueue.get_queue_length_by_key("cs241"))
+
         self.assertEqual(3, len(self.multiqueue.queues))
         self.assertEqual(2, self.multiqueue.queues["cs225"].qsize())
         self.assertEqual(1, self.multiqueue.queues["cs233"].qsize())

--- a/tests/api/unit/test_utils.py
+++ b/tests/api/unit/test_utils.py
@@ -67,9 +67,9 @@ class TestMultiQueue(BaseTest):
         self.assertTrue(self.multiqueue.contains_key("cs241"))
         self.assertFalse(self.multiqueue.contains_key("ece411"))
 
-        self.assertEqual(2, self.multiqueue.get_queue_length_by_key("cs225"))
-        self.assertEqual(1, self.multiqueue.get_queue_length_by_key("cs233"))
-        self.assertEqual(2, self.multiqueue.get_queue_length_by_key("cs241"))
+        self.assertEqual(2, self.multiqueue.get_queue_length("cs225"))
+        self.assertEqual(1, self.multiqueue.get_queue_length("cs233"))
+        self.assertEqual(2, self.multiqueue.get_queue_length("cs241"))
 
         self.assertEqual(3, len(self.multiqueue.queues))
         self.assertEqual(2, self.multiqueue.queues["cs225"].qsize())

--- a/tests/api/unit/test_utils.py
+++ b/tests/api/unit/test_utils.py
@@ -92,23 +92,22 @@ class TestMultiQueue(BaseTest):
             self.multiqueue.push("cs241", "cs241-" + str(i))
 
         for i in range(10):
-            self.assertEqual(i, self.multiqueue.get_position_in_queue(
-                "cs225", "cs225-" + str(i)))
+            self.assertEqual(
+                i, self.multiqueue.get_position_in_queue("cs225", "cs225-" + str(i))
+            )
 
         for i in range(100):
-            self.assertEqual(i, self.multiqueue.get_position_in_queue(
-                "cs233", "cs233-" + str(i)
-            ))
+            self.assertEqual(
+                i, self.multiqueue.get_position_in_queue("cs233", "cs233-" + str(i))
+            )
 
         for i in range(241):
-            self.assertEqual(i, self.multiqueue.get_position_in_queue(
-                "cs241", "cs241-" + str(i)
-            ))
+            self.assertEqual(
+                i, self.multiqueue.get_position_in_queue("cs241", "cs241-" + str(i))
+            )
 
         # try getting the position of a non-existent key
-        self.assertEqual(-1, self.multiqueue.get_position_in_queue(
-            "cs225", "foo"
-        ))
+        self.assertEqual(-1, self.multiqueue.get_position_in_queue("cs225", "foo"))
 
     def test_pull(self):
 

--- a/tests/api/unit/test_utils.py
+++ b/tests/api/unit/test_utils.py
@@ -76,6 +76,40 @@ class TestMultiQueue(BaseTest):
         self.assertEqual(1, self.multiqueue.queues["cs233"].qsize())
         self.assertEqual(2, self.multiqueue.queues["cs241"].qsize())
 
+    def test_position(self):
+
+        # try getting the position of some key in a non-existent queue
+        with self.assertRaises(Exception):
+            self.multiqueue.get_position_in_queue("foo", "")
+
+        for i in range(10):
+            self.multiqueue.push("cs225", "cs225-" + str(i))
+
+        for i in range(100):
+            self.multiqueue.push("cs233", "cs233-" + str(i))
+
+        for i in range(241):
+            self.multiqueue.push("cs241", "cs241-" + str(i))
+
+        for i in range(10):
+            self.assertEqual(i, self.multiqueue.get_position_in_queue(
+                "cs225", "cs225-" + str(i)))
+
+        for i in range(100):
+            self.assertEqual(i, self.multiqueue.get_position_in_queue(
+                "cs233", "cs233-" + str(i)
+            ))
+
+        for i in range(241):
+            self.assertEqual(i, self.multiqueue.get_position_in_queue(
+                "cs241", "cs241-" + str(i)
+            ))
+
+        # try getting the position of a non-existent key
+        self.assertEqual(-1, self.multiqueue.get_position_in_queue(
+            "cs225", "foo"
+        ))
+
     def test_pull(self):
 
         # try pulling from a multiqueue that is empty


### PR DESCRIPTION
I added an endpoint to see where in a course's queue a grading run is. This can be used in on-demand to give students their up-to-date position in the grading queue.

I still have to add tests for this functionality.

Depends on #26 

Relates to https://github.com/illinois-cs241/broadway-on-demand/issues/80