### PR TITLE
Add Query Tokens (View Only) to courses

### DIFF
--- a/broadway/api/daos/course.py
+++ b/broadway/api/daos/course.py
@@ -31,9 +31,16 @@ class CourseDao(BaseDao):
     def _from_store(self, obj) -> Optional[Course]:
         if obj is None:
             return None
-        attrs = {"id_": obj.get(CourseDao.ID), "tokens": obj.get(
-            CourseDao.TOKENS), "query_tokens": obj.get(CourseDao.QUERY_TOKENS)}
+        attrs = {
+            "id_": obj.get(CourseDao.ID),
+            "tokens": obj.get(CourseDao.TOKENS),
+            "query_tokens": obj.get(CourseDao.QUERY_TOKENS),
+        }
         return Course(**attrs)
 
     def _to_store(self, obj) -> dict:
-        return {CourseDao.ID: obj.id, CourseDao.TOKENS: obj.tokens, CourseDao.QUERY_TOKENS: obj.query_tokens}
+        return {
+            CourseDao.ID: obj.id,
+            CourseDao.TOKENS: obj.tokens,
+            CourseDao.QUERY_TOKENS: obj.query_tokens,
+        }

--- a/broadway/api/daos/course.py
+++ b/broadway/api/daos/course.py
@@ -8,6 +8,7 @@ from broadway.api.models import Course
 class CourseDao(BaseDao):
     ID = "_id"
     TOKENS = "tokens"
+    QUERY_TOKENS = "query_tokens"
     _COLLECTION = "course"
 
     def __init__(self, app):
@@ -30,8 +31,9 @@ class CourseDao(BaseDao):
     def _from_store(self, obj) -> Optional[Course]:
         if obj is None:
             return None
-        attrs = {"id_": obj.get(CourseDao.ID), "tokens": obj.get(CourseDao.TOKENS)}
+        attrs = {"id_": obj.get(CourseDao.ID), "tokens": obj.get(
+            CourseDao.TOKENS), "query_tokens": obj.get(CourseDao.QUERY_TOKENS)}
         return Course(**attrs)
 
     def _to_store(self, obj) -> dict:
-        return {CourseDao.ID: obj.id, CourseDao.TOKENS: obj.tokens}
+        return {CourseDao.ID: obj.id, CourseDao.TOKENS: obj.tokens, CourseDao.QUERY_TOKENS: obj.query_tokens}

--- a/broadway/api/decorators/auth.py
+++ b/broadway/api/decorators/auth.py
@@ -1,5 +1,4 @@
 import logging
-from functools import partial
 
 from broadway.api.daos import AssignmentConfigDao, CourseDao, WorkerNodeDao
 
@@ -110,6 +109,7 @@ def authenticate_course_wrapper_generator(admin_only, func):
             return
 
         return func(*args, **kwargs)
+
     return wrapper
 
 

--- a/broadway/api/decorators/auth.py
+++ b/broadway/api/decorators/auth.py
@@ -1,4 +1,5 @@
 import logging
+from functools import partial
 
 from broadway.api.daos import AssignmentConfigDao, CourseDao, WorkerNodeDao
 
@@ -81,7 +82,7 @@ def authenticate_cluster_token_ws(func):
     return wrapper
 
 
-def authenticate_course(func):
+def authenticate_course_wrapper_generator(admin_only, func):
     def wrapper(*args, **kwargs):
         handler = args[0]
 
@@ -99,17 +100,31 @@ def authenticate_course(func):
             handler.abort({"message": "course not found"}, status=401)
             return
 
-        if request_token not in course.tokens:
+        if admin_only:
+            allowed_tokens = set(course.tokens)
+        else:
+            allowed_tokens = set(course.tokens).union(set(course.query_tokens))
+
+        if request_token not in allowed_tokens:
             handler.abort({"message": "invalid token"}, status=401)
             return
-        return func(*args, **kwargs)
 
+        return func(*args, **kwargs)
     return wrapper
+
+
+def authenticate_course_member_or_admin(func):
+    return authenticate_course_wrapper_generator(False, func)
+
+
+def authenticate_course_admin(func):
+    return authenticate_course_wrapper_generator(True, func)
 
 
 __all__ = [
     "authenticate_cluster_token",
-    "authenticate_course",
+    "authenticate_course_member_or_admin",
+    "authenticate_course_admin",
     "authenticate_worker",
     "validate_assignment",
 ]

--- a/broadway/api/definitions.py
+++ b/broadway/api/definitions.py
@@ -2,8 +2,7 @@ course_config = {
     "type": "object",
     "patternProperties": {
         "": {
-            "properties":
-            {
+            "properties": {
                 "tokens": {"type": "array", "items": {"type": "string"}},
                 "query_tokens": {"type": "array", "items": {"type": "string"}},
             },

--- a/broadway/api/definitions.py
+++ b/broadway/api/definitions.py
@@ -1,6 +1,15 @@
 course_config = {
     "type": "object",
-    "patternProperties": {"": {"type": "array", "items": {"type": "string"}}},
+    "patternProperties": {
+        "": {
+            "properties":
+            {
+                "tokens": {"type": "array", "items": {"type": "string"}},
+                "query_tokens": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["tokens"],
+        },
+    },
 }
 
 grading_stage = {

--- a/broadway/api/handlers/client.py
+++ b/broadway/api/handlers/client.py
@@ -6,7 +6,10 @@ from tornado_json import schema
 import broadway.api.daos as daos
 import broadway.api.definitions as definitions
 import broadway.api.models as models
-from broadway.api.decorators.auth import authenticate_course_admin, authenticate_course_member_or_admin
+from broadway.api.decorators.auth import (
+    authenticate_course_admin,
+    authenticate_course_member_or_admin,
+)
 from broadway.api.handlers.base import BaseAPIHandler
 from broadway.api.utils.run import continue_grading_run
 from broadway.api.utils.time import get_time

--- a/broadway/api/handlers/client.py
+++ b/broadway/api/handlers/client.py
@@ -6,7 +6,7 @@ from tornado_json import schema
 import broadway.api.daos as daos
 import broadway.api.definitions as definitions
 import broadway.api.models as models
-from broadway.api.decorators.auth import authenticate_course
+from broadway.api.decorators.auth import authenticate_course_admin, authenticate_course_member_or_admin
 from broadway.api.handlers.base import BaseAPIHandler
 from broadway.api.utils.run import continue_grading_run
 from broadway.api.utils.time import get_time
@@ -23,7 +23,7 @@ class ClientAPIHandler(BaseAPIHandler):
 
 
 class GradingConfigHandler(ClientAPIHandler):
-    @authenticate_course
+    @authenticate_course_admin
     @schema.validate(input_schema=definitions.grading_config)
     def post(self, *args, **kwargs):
         assignment_id = self.get_assignment_id(**kwargs)
@@ -34,7 +34,7 @@ class GradingConfigHandler(ClientAPIHandler):
         config_dao.delete_by_id(assignment_id)
         config_dao.insert(config)
 
-    @authenticate_course
+    @authenticate_course_admin
     @schema.validate(on_empty_404=True, output_schema=definitions.grading_config)
     def get(self, *args, **kwargs):
         assignment_id = self.get_assignment_id(**kwargs)
@@ -49,7 +49,7 @@ class GradingConfigHandler(ClientAPIHandler):
 
 
 class GradingRunHandler(ClientAPIHandler):
-    @authenticate_course
+    @authenticate_course_admin
     @schema.validate(
         input_schema={
             "type": "object",
@@ -131,7 +131,7 @@ class GradingRunHandler(ClientAPIHandler):
 
 
 class GradingRunStatusHandler(ClientAPIHandler):
-    @authenticate_course
+    @authenticate_course_member_or_admin
     @schema.validate(
         output_schema={
             "type": "object",
@@ -193,7 +193,7 @@ class GradingRunStatusHandler(ClientAPIHandler):
 
 
 class GradingJobLogHandler(ClientAPIHandler):
-    @authenticate_course
+    @authenticate_course_admin
     @schema.validate(
         output_schema={
             "type": "object",
@@ -222,7 +222,7 @@ class GradingJobLogHandler(ClientAPIHandler):
 
 
 class CourseWorkerNodeHandler(ClientAPIHandler):
-    @authenticate_course
+    @authenticate_course_admin
     @schema.validate(
         output_schema={
             "type": "object",
@@ -273,7 +273,7 @@ class CourseWorkerNodeHandler(ClientAPIHandler):
 
 
 class CourseQueueLengthHandler(ClientAPIHandler):
-    @authenticate_course
+    @authenticate_course_admin
     @schema.validate(
         output_schema={
             "type": "object",
@@ -295,7 +295,7 @@ class CourseQueueLengthHandler(ClientAPIHandler):
 
 
 class GradingJobQueuePositionHandler(ClientAPIHandler):
-    @authenticate_course
+    @authenticate_course_member_or_admin
     @schema.validate(
         output_schema={
             "type": "object",

--- a/broadway/api/handlers/stream.py
+++ b/broadway/api/handlers/stream.py
@@ -3,7 +3,7 @@ from tornado import gen, web
 from tornado.iostream import StreamClosedError
 
 from broadway.api.handlers.base import BaseAPIHandler
-from broadway.api.decorators.auth import authenticate_course
+from broadway.api.decorators.auth import authenticate_course_member_or_admin
 from broadway.api.utils.streamqueue import StreamQueue
 
 
@@ -28,7 +28,7 @@ class GradingJobStreamHandler(BaseAPIHandler):
         except StreamClosedError:
             self._stop_listening()
 
-    @authenticate_course
+    @authenticate_course_member_or_admin
     @gen.coroutine
     def get(self, **kwargs):
         self._job_id = kwargs.get("job_id")

--- a/broadway/api/models/course.py
+++ b/broadway/api/models/course.py
@@ -2,6 +2,7 @@ from typing import List
 
 
 class Course:
-    def __init__(self, id_: str, tokens: List[str] = []):
+    def __init__(self, id_: str, tokens: List[str] = [], query_tokens: List[str] = []):
         self.id = id_
         self.tokens = tokens
+        self.query_tokens = query_tokens

--- a/broadway/api/utils/bootstrap.py
+++ b/broadway/api/utils/bootstrap.py
@@ -96,8 +96,12 @@ def initialize_course_tokens(settings: Dict[str, Any], flags: Dict[str, Any]):
     course_dao = CourseDao(settings)
     course_dao.drop_all()
 
-    for course_id, tokens in courses.items():
-        course = Course(id_=course_id, tokens=tokens)
+    for course_id, course in courses.items():
+        course = Course(
+            id_=course_id,
+            tokens=course["tokens"],
+            query_tokens=course.get("query_tokens", [])
+        )
         course_dao.insert_or_update(course)
 
 

--- a/broadway/api/utils/bootstrap.py
+++ b/broadway/api/utils/bootstrap.py
@@ -100,7 +100,7 @@ def initialize_course_tokens(settings: Dict[str, Any], flags: Dict[str, Any]):
         course = Course(
             id_=course_id,
             tokens=course["tokens"],
-            query_tokens=course.get("query_tokens", [])
+            query_tokens=course.get("query_tokens", []),
         )
         course_dao.insert_or_update(course)
 

--- a/tests/_fixtures/test-course.json
+++ b/tests/_fixtures/test-course.json
@@ -1,3 +1,10 @@
 {
-    "test-course": ["course-token"]
+    "test-course": {
+        "tokens": [
+            "course-token"
+        ],
+        "query_tokens": [
+            "query-token"
+        ]
+    }
 }

--- a/tests/api/_utils/database.py
+++ b/tests/api/_utils/database.py
@@ -8,7 +8,7 @@ def initialize_db(settings, course_config):
         course = Course(
             id_=course_id,
             tokens=course["tokens"],
-            query_tokens=course.get("query_tokens", [])
+            query_tokens=course.get("query_tokens", []),
         )
         course_dao.insert_or_update(course)
 

--- a/tests/api/_utils/database.py
+++ b/tests/api/_utils/database.py
@@ -4,8 +4,12 @@ from broadway.api.daos.course import CourseDao
 
 def initialize_db(settings, course_config):
     course_dao = CourseDao(settings)
-    for course_id, tokens in course_config.items():
-        course = Course(id_=course_id, tokens=tokens)
+    for course_id, course in course_config.items():
+        course = Course(
+            id_=course_id,
+            tokens=course["tokens"],
+            query_tokens=course.get("query_tokens", [])
+        )
         course_dao.insert_or_update(course)
 
 

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -105,7 +105,6 @@ class ClientMixin(AsyncHTTPMixin):
             body=json.dumps(grading_config),
             headers=header,
         )
-        assert response.code == expected_code, repr(response.body)
         self.assertEqual(response.code, expected_code)
 
     def get_grading_config(self, course_id, assignment_name, header, expected_code):

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -88,6 +88,9 @@ class ClientMixin(AsyncHTTPMixin):
         super().__init__(*args, **kwargs)
         self.client_header1 = {"Authorization": "Bearer " + MOCK_CLIENT_TOKEN1}
         self.client_header2 = {"Authorization": "Bearer " + MOCK_CLIENT_TOKEN2}
+        self.client_header_query_token = {
+            "Authorization": "Bearer " + MOCK_CLIENT_QUERY_TOKEN
+        }
         self.course1 = MOCK_COURSE1
         self.course2 = MOCK_COURSE2
 

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -58,11 +58,11 @@ class AsyncHTTPMixin(AsyncHTTPTestCase):
             {
                 MOCK_COURSE1: {
                     "tokens": [MOCK_CLIENT_TOKEN1],
-                    "query_tokens": [MOCK_CLIENT_QUERY_TOKEN]
+                    "query_tokens": [MOCK_CLIENT_QUERY_TOKEN],
                 },
                 MOCK_COURSE2: {
                     "tokens": [MOCK_CLIENT_TOKEN1, MOCK_CLIENT_TOKEN2],
-                    "query_tokens": []
+                    "query_tokens": [],
                 },
             },
         )

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -25,6 +25,8 @@ MOCK_COURSE2 = "mock_course2"
 MOCK_CLIENT_TOKEN1 = "12345"
 MOCK_CLIENT_TOKEN2 = "67890"
 
+MOCK_CLIENT_QUERY_TOKEN = "C4OWEM2XHD"
+
 
 class AsyncHTTPMixin(AsyncHTTPTestCase):
     def __init__(self, *args, **kwargs):
@@ -54,8 +56,14 @@ class AsyncHTTPMixin(AsyncHTTPTestCase):
         database_utils.initialize_db(
             self.app.settings,
             {
-                MOCK_COURSE1: [MOCK_CLIENT_TOKEN1],
-                MOCK_COURSE2: [MOCK_CLIENT_TOKEN1, MOCK_CLIENT_TOKEN2],
+                MOCK_COURSE1: {
+                    "tokens": [MOCK_CLIENT_TOKEN1],
+                    "query_tokens": [MOCK_CLIENT_QUERY_TOKEN]
+                },
+                MOCK_COURSE2: {
+                    "tokens": [MOCK_CLIENT_TOKEN1, MOCK_CLIENT_TOKEN2],
+                    "query_tokens": []
+                },
             },
         )
 
@@ -94,6 +102,7 @@ class ClientMixin(AsyncHTTPMixin):
             body=json.dumps(grading_config),
             headers=header,
         )
+        assert response.code == expected_code, repr(response.body)
         self.assertEqual(response.code, expected_code)
 
     def get_grading_config(self, course_id, assignment_name, header, expected_code):

--- a/tests/api/integration/test_client.py
+++ b/tests/api/integration/test_client.py
@@ -526,6 +526,7 @@ class StreamEndpointTest(BaseTest):
             )
 
             # Keep track of the job ids
+            # Also tests that query token can be used for this endpoint
             run_state = self.get_grading_run_state(
                 self.course1, grading_run_id, self.client_header_query_token
             )
@@ -535,8 +536,8 @@ class StreamEndpointTest(BaseTest):
 
             def _create_callback(chunks):
                 def _callback(chunk):
-                    self.assertNotEquals(len(chunks), 0)
-                    self.assertEquals(chunk, chunks.pop())
+                    self.assertNotEqual(len(chunks), 0)
+                    self.assertEqual(chunk, chunks.pop())
 
                 return _callback
 
@@ -551,9 +552,10 @@ class StreamEndpointTest(BaseTest):
                 chunks.append(create_chunk("position", pos))
 
             self.get_grading_job_stream(
-                self.course1, job_id,
+                self.course1,
+                job_id,
                 self.client_header_query_token,
-                _create_callback(chunks)
+                _create_callback(chunks),
             )
 
         worker_id = self.register_worker(self.get_header())

--- a/tests/api/integration/test_client.py
+++ b/tests/api/integration/test_client.py
@@ -527,7 +527,7 @@ class StreamEndpointTest(BaseTest):
 
             # Keep track of the job ids
             run_state = self.get_grading_run_state(
-                self.course1, grading_run_id, self.client_header1
+                self.course1, grading_run_id, self.client_header_query_token
             )
             job_ids.append(list(run_state["student_jobs_state"].keys())[0])
 
@@ -551,7 +551,9 @@ class StreamEndpointTest(BaseTest):
                 chunks.append(create_chunk("position", pos))
 
             self.get_grading_job_stream(
-                self.course1, job_id, self.client_header1, _create_callback(chunks)
+                self.course1, job_id,
+                self.client_header_query_token,
+                _create_callback(chunks)
             )
 
         worker_id = self.register_worker(self.get_header())

--- a/tests/api/unit/test_utils.py
+++ b/tests/api/unit/test_utils.py
@@ -30,7 +30,7 @@ class TestCourseTokenUtils(BaseTest):
     def test_init_tokens(self):
         course_tokens = {
             "cs225": {"tokens": ["token1"]},
-            "cs241": {"tokens": ["token1"], "query_tokens": ["token2"]}
+            "cs241": {"tokens": ["token1"], "query_tokens": ["token2"]},
         }
 
         with mock.patch(

--- a/tests/api/unit/test_utils.py
+++ b/tests/api/unit/test_utils.py
@@ -28,7 +28,10 @@ class TestClusterTokenUtils(BaseTest):
 
 class TestCourseTokenUtils(BaseTest):
     def test_init_tokens(self):
-        course_tokens = {"cs225": ["token1"], "cs241": ["token1", "token2"]}
+        course_tokens = {
+            "cs225": {"tokens": ["token1"]},
+            "cs241": {"tokens": ["token1"], "query_tokens": ["token2"]}
+        }
 
         with mock.patch(
             "builtins.open", mock.mock_open(read_data=json.dumps(course_tokens))
@@ -44,8 +47,11 @@ class TestCourseTokenUtils(BaseTest):
 
         self.assertIn("token1", cs225.tokens)
         self.assertNotIn("token2", cs225.tokens)
+        self.assertNotIn("token1", cs225.query_tokens)
         self.assertIn("token1", cs241.tokens)
-        self.assertIn("token2", cs241.tokens)
+        self.assertNotIn("token1", cs241.query_tokens)
+        self.assertIn("token2", cs241.query_tokens)
+        self.assertNotIn("token2", cs241.tokens)
 
 
 class TestMultiQueue(BaseTest):


### PR DESCRIPTION
# Context
As of now, to query information from broadway (such as grading job status) one must use the course token for authentication. However, the same course token is used for adding new grading jobs, adding new assignments, and modifying existing assignments. This means broadway on-demand server cannot risk sending this token to the client (browser) because that gives the student the opportunity to learn this token. Previously on-demand have been using the server as a middle man to relay requests and results. This was slowing down the performance of status requests. However, for SSE endpoint integration, the overhead of the rely becomes too high. Hence we decided to create a new kind of token for each course.

# What's done
- Add `query_tokens` array to courses
- Replace `authenticate_course` function with `authenticate_course_admin` and `authenticate_course_member_or_admin`. 
    - `authenticate_course_admin` only allows users with a token in the `tokens` array of the course
    - `authenticate_course_member_or_admin` allows users with both `tokens` or `query_tokens`
- Separate all endpoints that used `authenticate_course` to use either of the replacement functions
    - `authenticate_course_admin`:
         - POST/GET Grading config
         - POST Grading run
         - GET Grading job log (grading job logs might have sensitive information such as test case assertions)
         - GET Worker node info
         - GET Course total queue length
    - `authenticate_course_member_or_admin`:
         - GET Grading run status
         - GET Grading job's queue position
         - GET Grading job status with streaming Server Side Event connection
- Updated existing test cases/course config schema
- [x] add a test case for using query tokens on one of the designated services

# Notes
Please note that if students do end up obtaining the query token, they will not be able to schedule more runs for themselves or modify current assignments. But, they will be able to query other students' grading run status/job queue position if they somehow obtain the job/run ids.