### PR TITLE
Allow Cross Origin Resource Sharing

### DIFF
--- a/broadway/api/handlers/base.py
+++ b/broadway/api/handlers/base.py
@@ -11,6 +11,20 @@ logger = logging.getLogger(__name__)
 
 
 class BaseAPIHandler(APIHandler):
+    def set_default_headers(self, *args, **kwargs):
+        self.set_header("Access-Control-Allow-Origin", "*")
+
+    def options(self, *args, **kwargs):
+        """
+        For CORS, browsers will send a preflight request with "OPTIONS" method before the 
+        actual request. We want to respond with a status of "HTTP OK", a header with 
+        proper "Access-Control-Allow-Origin" field for all origins we allow and a proper
+        "Access-Control-Allow-Headers" for all special header fields we allow, and no body.
+        """
+        self.set_header("Access-Control-Allow-Headers", "Authorization")
+        self.set_status(204)
+        self.finish()
+
     def abort(self, data, status=400):
         self.set_status(status)
         self.fail(data)

--- a/broadway/api/handlers/base.py
+++ b/broadway/api/handlers/base.py
@@ -16,10 +16,11 @@ class BaseAPIHandler(APIHandler):
 
     def options(self, *args, **kwargs):
         """
-        For CORS, browsers will send a preflight request with "OPTIONS" method before the 
-        actual request. We want to respond with a status of "HTTP OK", a header with 
-        proper "Access-Control-Allow-Origin" field for all origins we allow and a proper
-        "Access-Control-Allow-Headers" for all special header fields we allow, and no body.
+        For CORS, browsers will send a preflight request with "OPTIONS" method
+        before the actual request. We want to respond with a status of "HTTP OK",
+        a header with proper "Access-Control-Allow-Origin" field for all origins
+        we allow and a proper "Access-Control-Allow-Headers" for all special
+        header fields we allow, and no body.
         """
         self.set_header("Access-Control-Allow-Headers", "Authorization")
         self.set_status(204)


### PR DESCRIPTION
After #35, we hope to use on-demand client code to make direct queries to broadway endpoints. However more needs to be done for that to come true. Since broadway and on-demand are hosted on different machines, they are on different origin. Therefore broadway must allow cross origin resource sharing. 

I chose to put `*` in `Access-Control-Allow-Origin` instead of just on-demand and localhost. This means browsers will allow any other website to access broadway data. This is okay because broadway does not use cookies as a form of authentication. The main reason for browsers to block cross origin requests is to prevent cookies to be sent automatically along with the request. Hence we do not take any risk by doing this.

I also just learned about [preflight request](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) when working on this. Because we use the "Authentication" header field, browsers send a preflight request with "OPTIONS" type before the actual "POST" request. Broadway must respond that we allow "Authentication" field.