### PR TITLE
Fix non-stop heartbeating for stream endpoint

### DIFF
--- a/broadway/api/handlers/stream.py
+++ b/broadway/api/handlers/stream.py
@@ -16,6 +16,10 @@ class GradingJobStreamHandler(BaseAPIHandler):
         self.set_header("Content-Type", "text/event-stream")
         self.set_header("Cache-Control", "no-cache")
 
+        # No need to register stream or callback when it's a preflight request
+        if self.request.method == "OPTIONS":
+            return
+
         self._id = id(self)
         self._callback = PeriodicCallback(
             callback=self._heartbeat, callback_time=HEARTBEAT_TIME_MILLI


### PR DESCRIPTION
Turns out the preflight requests passed the `initialize` method, `self.finish` was called but `_stop_listening` wasn't. So the heartbeat never stopped. This PR should fix it.