### PR TITLE
Add no buffering header to SSEs

### DIFF
--- a/broadway/api/handlers/stream.py
+++ b/broadway/api/handlers/stream.py
@@ -16,6 +16,10 @@ class GradingJobStreamHandler(BaseAPIHandler):
         self.set_header("Content-Type", "text/event-stream")
         self.set_header("Cache-Control", "no-cache")
 
+        # Needed for SSEs to work with nginx.
+        # See https://serverfault.com/a/801629
+        self.set_header("X-Accel-Buffering", "no")
+
         # No need to register stream or callback when it's a preflight request
         if self.request.method == "OPTIONS":
             return


### PR DESCRIPTION
Adds no buffering header for SSEs. This should make it work with nginx. 
https://serverfault.com/a/801629

Tested locally by setting up nginx and pointing on-demand's `BROADWAY_API_URL` to the nginx url instead of directly to the server.
- With the current `illinois-241/broadway-api` image, on-demand doesn't receive any heartbeats (just like how it is with the production version).
- With an image containing these changes, on-demand receives the heartbeats and return the error anymore.