### PR TITLE
Update definitions.py

### DIFF
--- a/broadway/api/definitions.py
+++ b/broadway/api/definitions.py
@@ -21,6 +21,7 @@ grading_stage = {
         "privileged": {"type": "boolean"},
         "hostname": {"type": "string"},
         "timeout": {"type": "number"},
+        "cpuset_cpus": {"type": "string"},
         "memory": {"type": "string"},
         "logs": {"type": "boolean"},
     },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/illinois-cs241/chainlink@0.0.7
+git+https://github.com/illinois-cs241/chainlink@0.0.8
 git+https://github.com/illinois-cs241/flagset@0.0.3
 pymongo==3.9.0
 tornado==5.1.1


### PR DESCRIPTION
Update grading stage schema to include "cpuset_cpus" string parameter introduced to ChainLink in [PR 29](https://github.com/illinois-cs241/chainlink/pull/29).